### PR TITLE
Support recording pageview events

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ Delete Customer:
 
     deleteCustomer('someid001');
 
-
 Fire Event:
 
     fireEvent('someid001', 'event-name', array('arbitrary-value', 3.14));
+
+Record Pageview:
+
+    fireEvent('someid001', 'https://www.full-pageview-url.com/', 'https://www.optional-full-referrer-url.com/');
 
 ## Response Object
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Fire Event:
 
 Record Pageview:
 
-    fireEvent('someid001', 'https://www.full-pageview-url.com/', 'https://www.optional-full-referrer-url.com/');
+    recordPageview('someid001', 'https://www.full-pageview-url.com/', 'https://www.optional-full-referrer-url.com/');
 
 ## Response Object
 

--- a/src/Customerio/Api.php
+++ b/src/Customerio/Api.php
@@ -34,4 +34,9 @@ class Api {
     {
         return $this->request->authenticate($this->siteId, $this->apiSecret)->event($id, $name, $data);
     }
+
+    public function recordPageview($id, $url, $referrer)
+    {
+        return $this->request->authenticate($this->siteId, $this->apiSecret)->pageview($id, $url, $referrer);
+    }
 }

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -79,7 +79,7 @@ class Request {
     }
 
     /**
-     * Send and Event to Customer.io
+     * Send a pageview to Customer.io
      * @param $id
      * @param $url
      * @param $referrer

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -87,7 +87,7 @@ class Request {
      */
     public function pageview($id, $url, $referrer = '')
     {
-        $body = array_merge( array('name' => $url, 'type' => 'page'), $this->parseData( array( 'referrer', $referrer ) ) );
+        $body = array_merge( array('name' => $url, 'type' => 'page'), $this->parseData( array( 'referrer' => $referrer ) ) );
 
         try {
             $response = $this->client->post('/api/v1/customers/'.$id.'/events', null, $body, array(

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -81,6 +81,30 @@ class Request {
     /**
      * Send and Event to Customer.io
      * @param $id
+     * @param $url
+     * @param $referrer
+     * @return Response
+     */
+    public function pageview($id, $url, $referrer = '')
+    {
+        $body = array_merge( array('name' => $url, 'type' => 'page'), $this->parseData( array( 'referrer', $referrer ) ) );
+
+        try {
+            $response = $this->client->post('/api/v1/customers/'.$id.'/events', null, $body, array(
+                'auth' => $this->auth,
+            ))->send();
+        } catch (BadResponseException $e) {
+            $response = $e->getResponse();
+        } catch (RequestException $e) {
+            return new Response($e->getCode(), $e->getMessage());
+        }
+
+        return new Response($response->getStatusCode(), $response->getReasonPhrase());
+    }
+
+    /**
+     * Send and Event to Customer.io
+     * @param $id
      * @param $name
      * @param $data
      * @return Response

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -70,6 +70,21 @@ class ApiTest extends TestCase  {
         $this->assertTrue( $response->success() );
     }
 
+    public function testRecordPageview()
+    {
+        $id = $this->getRandomString();
+
+        $url = 'http://' . $this->getRandomString(8) . '.com/';
+
+        $referrer = 'http://' . $this->getRandomString(8) . '.com/';
+
+        $api = $this->createApi();
+
+        $response = $api->recordPageview($id, $url, $referrer);
+
+        $this->assertTrue( $response->success() );
+    }
+
     protected function getEmail()
     {
         return $this->getRandomString(5).'@'.$this->getRandomString(10).'.com';
@@ -113,6 +128,10 @@ class ApiTest extends TestCase  {
 
         $stub->expects($this->any())
             ->method('event')
+            ->will($this->returnValue(new Response(200, 'Ok')));
+
+        $stub->expects($this->any())
+            ->method('pageview')
             ->will($this->returnValue(new Response(200, 'Ok')));
 
         return $stub;


### PR DESCRIPTION
The Customer.io API handles pageviews slightly differently from other events, even though they both get passed to the /events endpoint.

This pull request adds support for a new method, `recordPageview`. It takes three parameters: an ID, a pageview URL (in full, protocol and all) and an optional referrer URL (in full, protocol and all).

For example, this code...

```php
$response = $this->api->recordPageview(
    3,
    'https://www.google.com/intl/en/about/',
    'https://www.google.com/'
);
```

...will trigger a pageview event in Customer.io, like so...

![customer_io](https://cloud.githubusercontent.com/assets/1231306/6846316/701c3cc4-d3bd-11e4-91bb-0d9949d3f8ff.png)

...which can be used to create pageview-based segments and email triggers.

This was my first time using PHPUnit, but I believe I created the tests correctly and they seem to pass on my machine.