### PR TITLE
Parse data as JSON for more flexibility

### DIFF
--- a/src/Customerio/Api.php
+++ b/src/Customerio/Api.php
@@ -30,14 +30,14 @@ class Api {
         return $this->request->authenticate($this->siteId, $this->apiSecret)->deleteCustomer($id);
     }
 
-    public function fireEvent($id, $name, $data=array())
+    public function fireEvent($id, $name, $data=array(), $formatJson = false)
     {
-        return $this->request->authenticate($this->siteId, $this->apiSecret)->event($id, $name, $data);
+        return $this->request->authenticate($this->siteId, $this->apiSecret)->event($id, $name, $data, $formatJson);
     }
 
-    public function fireAnonymousEvent($name, $data=array())
+    public function fireAnonymousEvent($name, $data=array(), $formatJson = false)
     {
-        return $this->request->authenticate($this->siteId, $this->apiSecret)->anonymousEvent($name, $data);
+        return $this->request->authenticate($this->siteId, $this->apiSecret)->anonymousEvent($name, $data, $formatJson);
     }
 
     public function recordPageview($id, $url, $referrer)

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -188,20 +188,22 @@ class Request {
                 }
 
                 $parsed .= ($first ? '' : ',') . ($isAssoc ? '"' . $key . '":' : '') . $value;
-                
+
                 $first &= false;
             }
-            
+
             return $parsed . ($isAssoc ? '}' : ']');
         } else {
             $parsed = array();
 
-            foreach ($data as $key => $value)
+            foreach ($data['data'] as $key => $value)
             {
                 $parsed['data['.$key.']'] = $value;
             }
 
-            return $parsed;
+            unset($data['data']);
+
+            return array_merge($data, $parsed);
         }
     }
 

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -112,7 +112,7 @@ class Request {
      */
     public function event($id, $name, $data, $formatJson)
     {
-        $body = $this->parseData(array('name' => $name, 'data' => $data));
+        $body = $this->parseData(array('name' => $name, 'data' => $data), $formatJson);
 
         try {
             $response = $this->client->post('/api/v1/customers/'.$id.'/events', null, $body, array(


### PR DESCRIPTION
Please be warn that this change might introduce breaking change for people that were using for loops with non associative array.

Previously, if you were to send something like `[1,2,3]`, you had to loop this way in Liquid : 

    {% for hash in list %}
        {{ hash[0] }}
    {% endfor %}

Now, non associative arrays will remain non associative

    {% for item in list %}
        {{ item }}
    {% endfor %}

This gives you the possibility to use filters such as `sort` in your customerIo templates