### PR TITLE
Update guzzle request with plain string

### DIFF
--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -44,6 +44,7 @@ class Request {
     public function customer($id, $email, $attributes)
     {
         $body = array_merge(array('email' => $email), $attributes);
+        $body = http_build_query($body);
 
         try {
             $response = $this->client->put('/api/v1/customers/'.$id, null, $body, array(
@@ -88,6 +89,7 @@ class Request {
     public function pageview($id, $url, $referrer = '')
     {
         $body = array_merge( array('name' => $url, 'type' => 'page'), $this->parseData( array( 'referrer' => $referrer ) ) );
+        $body = http_build_query($body);
 
         try {
             $response = $this->client->post('/api/v1/customers/'.$id.'/events', null, $body, array(
@@ -112,6 +114,7 @@ class Request {
     public function event($id, $name, $data)
     {
         $body = array_merge( array('name' => $name), $this->parseData($data) );
+        $body = http_build_query($body);
 
         try {
             $response = $this->client->post('/api/v1/customers/'.$id.'/events', null, $body, array(
@@ -135,6 +138,7 @@ class Request {
     public function anonymousEvent($name, $data)
     {
         $body = array_merge( array('name' => $name), $this->parseData($data) );
+        $body = http_build_query($body);
 
         try {
             $response = $this->client->post('/api/v1/events', null, $body, array(


### PR DESCRIPTION
Update calls to guzzle to use a prepared request body string instead of array.  This will ensure that guzzle does not attempt to parse attribute values, specifically any attribute value that begins with '@' which can result in a security issue by opening up local files.