### PR TITLE
Upgrade to Guzzle 6 (and a few other improvements)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,10 @@
         }
     ],
     "require": {
-        "guzzle/guzzle": "3.9.*"
+        "guzzlehttp/guzzle": "6.*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "5.5.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -1,13 +1,13 @@
 <?php namespace Customerio;
 
-use Guzzle\Http\Exception\RequestException;
-use Guzzle\Http\Exception\BadResponseException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
 
 class Request {
 
     /**
      * An HTTP Client
-     * @var \Guzzle\Http\Client
+     * @var \GuzzleHttp\Client
      */
     protected $client;
 
@@ -31,7 +31,9 @@ class Request {
             return;
         }
 
-        $this->client = new \Guzzle\Http\Client('https://track.customer.io');
+        $this->client = new \GuzzleHttp\Client([
+            'base_uri' => 'https://track.customer.io',
+        ]);
     }
 
     /**
@@ -46,9 +48,10 @@ class Request {
         $body = array_merge(array('email' => $email), $attributes);
 
         try {
-            $response = $this->client->put('/api/v1/customers/'.$id, null, $body, array(
+            $response = $this->client->put('/api/v1/customers/'.$id, array(
                 'auth' => $this->auth,
-            ))->send();
+                'json' => $body,
+            ));
         } catch (BadResponseException $e) {
             $response = $e->getResponse();
         } catch (RequestException $e) {
@@ -66,9 +69,9 @@ class Request {
     public function deleteCustomer($id)
     {
         try {
-            $response = $this->client->delete('/api/v1/customers/'.$id, null, null, array(
+            $response = $this->client->delete('/api/v1/customers/'.$id, array(
                 'auth' => $this->auth,
-            ))->send();
+            ));
         } catch (BadResponseException $e) {
             $response = $e->getResponse();
         } catch (RequestException $e) {
@@ -90,9 +93,10 @@ class Request {
         $body = array_merge( array('name' => $url, 'type' => 'page'), $this->parseData( array( 'referrer' => $referrer ) ) );
 
         try {
-            $response = $this->client->post('/api/v1/customers/'.$id.'/events', null, $body, array(
+            $response = $this->client->post('/api/v1/customers/'.$id.'/events', array(
                 'auth' => $this->auth,
-            ))->send();
+                'json' => $body,
+            ));
         } catch (BadResponseException $e) {
             $response = $e->getResponse();
         } catch (RequestException $e) {
@@ -114,9 +118,10 @@ class Request {
         $body = array_merge( array('name' => $name), $this->parseData($data) );
 
         try {
-            $response = $this->client->post('/api/v1/customers/'.$id.'/events', null, $body, array(
+            $response = $this->client->post('/api/v1/customers/'.$id.'/events', array(
                 'auth' => $this->auth,
-            ))->send();
+                'json' => $body,
+            ));
         } catch (BadResponseException $e) {
             $response = $e->getResponse();
         } catch (RequestException $e) {
@@ -137,9 +142,10 @@ class Request {
         $body = array_merge( array('name' => $name), $this->parseData($data) );
 
         try {
-            $response = $this->client->post('/api/v1/events', null, $body, array(
+            $response = $this->client->post('/api/v1/events', array(
                 'auth' => $this->auth,
-            ))->send();
+                'json' => $body,
+            ));
         } catch (BadResponseException $e) {
             $response = $e->getResponse();
         } catch (RequestException $e) {
@@ -171,14 +177,7 @@ class Request {
      */
     protected function parseData(array $data)
     {
-        $parsed = array();
-
-        foreach( $data as $key => $value)
-        {
-            $parsed['data['.$key.']'] = $value;
-        }
-
-        return $parsed;
+        return array('data' => $data);
     }
 
 }


### PR DESCRIPTION
[Guzzle 3 is EOL](https://github.com/guzzle/guzzle3). Guzzle 6 is awesome. Time for an upgrade!

This pull request does a few things:

+   Replaces Guzzle 3 with Guzzle 6
+   Updates the Request class to utilise a Guzzle 6 client
    +   Fixes #16/#17; Guzzle 6 no longer auto-imports files from strings with `@` symbols prepended
+   Sends data to Customer.io as JSON
    +   Fixes #14/#15; submitting as JSON correctly converts arrays to hashes
+    Adds phpunit as a dev dependency, for easier local testing (via `vendor/bin/phpunit`)

Tests (as run on my local system) pass smoothly in versions of PHP supported by Guzzle 6 (5.5+). Yes, this would require dropping support for 5.3 and 5.4.