### PR TITLE
properly convert empty arrays to empty JSON objects; fixes #20

### DIFF
--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -180,7 +180,7 @@ class Request {
     {
 		if (empty($data))
 		{
-			$data = new stdClass;
+			$data = new stdClass();
 		}
 
         return array('data' => $data);

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -2,6 +2,7 @@
 
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\BadResponseException;
+use stdClass;
 
 class Request {
 
@@ -177,6 +178,11 @@ class Request {
      */
     protected function parseData(array $data)
     {
+		if (empty($data))
+		{
+			$data = new stdClass;
+		}
+
         return array('data' => $data);
     }
 


### PR DESCRIPTION
[See #20]

Confirmed with Customer.io that the PHP-default behaviour should continue to fail (and in fact, always should have failed).

This PR fixes the issue by setting empty `$data` values to an empty `stdClass`, which is converted to an empty JSON object instead of an empty JSON collection.