### PR TITLE
Add optional timestamp parameter to fireEvent() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Fire Event:
 
     fireEvent('someid001', 'event-name', array('arbitrary-value' => 3.14));
 
+Fire Historical Event:
+
+    fireEvent('someid001', 'event-name', array('arbitrary-value' => 3.14), 1420070400);
+
 Fire Anonymous Event: (http://customer.io/docs/invitation-emails.html)
 
     fireAnonymousEvent('event-name', array('arbitrary-value' => 3.14));

--- a/src/Customerio/Api.php
+++ b/src/Customerio/Api.php
@@ -30,9 +30,9 @@ class Api {
         return $this->request->authenticate($this->siteId, $this->apiSecret)->deleteCustomer($id);
     }
 
-    public function fireEvent($id, $name, $data=array())
+    public function fireEvent($id, $name, $data=array(), $timestamp=null)
     {
-        return $this->request->authenticate($this->siteId, $this->apiSecret)->event($id, $name, $data);
+        return $this->request->authenticate($this->siteId, $this->apiSecret)->event($id, $name, $data, $timestamp);
     }
 
     public function fireAnonymousEvent($name, $data=array())

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -112,11 +112,16 @@ class Request {
      * @param $id
      * @param $name
      * @param $data
+     * @param $timestamp (optional)
      * @return Response
      */
-    public function event($id, $name, $data)
+    public function event($id, $name, $data, $timestamp)
     {
-        $body = array_merge( array('name' => $name), $this->parseData($data) );
+        if (is_null($timestamp)) {
+            $body = array_merge( array('name' => $name), $this->parseData($data) );
+        } else {
+            $body = array_merge( array('name' => $name, 'timestamp' => $timestamp), $this->parseData($data) );
+        }
 
         try {
             $response = $this->client->post('/api/v1/customers/'.$id.'/events', array(

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -70,6 +70,23 @@ class ApiTest extends TestCase  {
         $this->assertTrue( $response->success() );
     }
 
+    public function testFireBacklogEvent()
+    {
+        $id = $this->getRandomString();
+
+        $name = $this->getRandomString();
+
+        $data = $this->getAttributes();
+
+        $timestamp = $this->getTimestamp();
+
+        $api = $this->createApi();
+
+        $response = $api->fireEvent($id, $name, $data, $timestamp);
+
+        $this->assertTrue( $response->success() );
+    }
+
     public function testFireAnonymousEvent()
     {
         $name = $this->getRandomString();
@@ -111,6 +128,12 @@ class ApiTest extends TestCase  {
         return array(
             $key => $value
         );
+    }
+
+    protected function getTimestamp()
+    {
+        $date = new DateTime();
+        return $date->getTimestamp();
     }
 
     protected function createApi()


### PR DESCRIPTION
Fixes #22 

The Customer.io API supports an optional timestamp value in event tracking calls to specify historical events for the purpose of backfilling event data. This PR introduces an additional `$timestamp` parameter to the `fireEvent()` method to support this use-case.