### PR TITLE
Make email optional on customer update

### DIFF
--- a/src/Customerio/Api.php
+++ b/src/Customerio/Api.php
@@ -20,7 +20,7 @@ class Api {
         return $this->request->authenticate($this->siteId, $this->apiSecret)->customer($id, $email, $attributes);
     }
 
-    public function updateCustomer($id, $email, $attributes=array())
+    public function updateCustomer($id, $email=null, $attributes=array())
     {
         return $this->createCustomer($id, $email, $attributes);
     }

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -46,7 +46,9 @@ class Request {
      */
     public function customer($id, $email, $attributes)
     {
-        $body = array_merge(array('email' => $email), $attributes);
+        if (! is_null($email)) {
+            $body = array_merge(array('email' => $email), $attributes);
+        }
 
         try {
             $response = $this->client->put('/api/v1/customers/'.$id, array(


### PR DESCRIPTION
Don't require email to be sent on a customer update request. With the API, if you have the ID, it is possible to update attributes without having to specify email, so that should be allowed here as well.