### PR TITLE
Add support for adding customers to a manual segment

### DIFF
--- a/src/Customerio/Api.php
+++ b/src/Customerio/Api.php
@@ -44,4 +44,9 @@ class Api {
     {
         return $this->request->authenticate($this->siteId, $this->apiSecret)->pageview($id, $url, $referrer);
     }
+
+    public function addToSegment($segment, array $users = []) 
+    {
+        return $this->request->authenticate($this->siteId, $this->apiSecret)->addToSegment($segment, $users);
+    }
 }

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -161,6 +161,24 @@ class Request {
         return new Response($response->getStatusCode(), $response->getReasonPhrase());
     }
 
+    public function addToSegment($segment, $users = [])
+    {
+        $body = ['ids' => $users];
+
+        try {
+            $response = $this->client->post("/api/v1/segments/$segment/add_customers", [
+                'auth' => $this->auth,
+                'json' => $body,
+            ]);
+        } catch (BadResponseException $e) {
+            $response = $e->getResponse();
+        } catch (RequestException $e) {
+            return new Response($e->getCode(), $e->getMessage());
+        }
+
+        return new Response($response->getStatusCode(), $response->getReasonPhrase());
+    }
+
     /**
      * Set Authentication credentials
      * @param $apiKey

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -115,6 +115,17 @@ class ApiTest extends TestCase  {
         $this->assertTrue( $response->success() );
     }
 
+    public function testAddToSegment()
+    {
+        $segmentId = $this->getRandomString();
+        $users = [$this->getRandomString(), $this->getRandomString()];
+
+        $api = $this->createApi();
+        $response = $api->addToSegment($segmentId, $users);
+        
+        $this->assertTrue( $response->success() );
+    }
+
     protected function getEmail()
     {
         return $this->getRandomString(5).'@'.$this->getRandomString(10).'.com';
@@ -173,6 +184,10 @@ class ApiTest extends TestCase  {
         $stub->expects($this->any())
             ->method('pageview')
             ->will($this->returnValue(new Response(200, 'Ok')));
+        
+        $stub->expects($this->any())
+            ->method('addToSegment')
+            ->will($this->returnValue(new Response(200, 'OK')));
 
         return $stub;
     }


### PR DESCRIPTION
This change adds the ability to add customers to a manual segment in CIO.