### PR TITLE
Add support for adding customers to a manual segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Record Pageview:
 
     recordPageview('someid001', 'https://www.full-pageview-url.com/', 'https://www.optional-full-referrer-url.com/');
 
+Add Customers to segment:
+
+    addToSegment('segmentId', ['customerId1', 'customerId2', 'customerId3',...]);
+
 ## Response Object
 
 All methods return a `Response` object which contains the following methods:

--- a/src/Customerio/Api.php
+++ b/src/Customerio/Api.php
@@ -44,4 +44,9 @@ class Api {
     {
         return $this->request->authenticate($this->siteId, $this->apiSecret)->pageview($id, $url, $referrer);
     }
+
+    public function addToSegment($segment, array $users = []) 
+    {
+        return $this->request->authenticate($this->siteId, $this->apiSecret)->addToSegment($segment, $users);
+    }
 }

--- a/src/Customerio/Request.php
+++ b/src/Customerio/Request.php
@@ -162,6 +162,39 @@ class Request {
     }
 
     /**
+     * @param $segment int
+     * @param $users array
+     * @return Response
+     */
+    public function addToSegment($segment, $users = [])
+    {
+        $body = ['ids' => self::parseIntData($users)];
+
+        try {
+            $response = $this->client->post("/api/v1/segments/$segment/add_customers", [
+                'auth' => $this->auth,
+                'json' => $body,
+            ]);
+        } catch (BadResponseException $e) {
+            $response = $e->getResponse();
+        } catch (RequestException $e) {
+            $response = new Response($e->getCode(), $e->getMessage());
+        }
+
+        return new Response($response->getStatusCode(), $response->getReasonPhrase());
+    }
+
+    // Parses int ID values to strings - API fails silently if ints are provided in json body
+    private static function parseIntData($userIds)
+    {
+        foreach ($userIds as $key => $userId) {
+            $userIds[$key] = (string) $userId;
+        }
+
+        return $userIds;
+    }
+
+    /**
      * Set Authentication credentials
      * @param $apiKey
      * @param $apiSecret

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -115,6 +115,17 @@ class ApiTest extends TestCase  {
         $this->assertTrue( $response->success() );
     }
 
+    public function testAddToSegment()
+    {
+        $segmentId = $this->getRandomString();
+        $users = [$this->getRandomString(), $this->getRandomString()];
+
+        $api = $this->createApi();
+        $response = $api->addToSegment($segmentId, $users);
+        
+        $this->assertTrue( $response->success() );
+    }
+
     protected function getEmail()
     {
         return $this->getRandomString(5).'@'.$this->getRandomString(10).'.com';
@@ -173,6 +184,10 @@ class ApiTest extends TestCase  {
         $stub->expects($this->any())
             ->method('pageview')
             ->will($this->returnValue(new Response(200, 'Ok')));
+        
+        $stub->expects($this->any())
+            ->method('addToSegment')
+            ->will($this->returnValue(new Response(200, 'OK')));
 
         return $stub;
     }


### PR DESCRIPTION
This change adds the ability to add customers to a manual segment in CIO.

Will need documentation.